### PR TITLE
fix: renamed 'visulization' to 'visualization' in readme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies=[
 ]
 
 [project.optional-dependencies]
-visulization = [
+visualization = [
     "smplx",
     "projectaria_tools",
     "chumpy @ git+https://github.com/mattloper/chumpy.git@master",

--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ git submodule update --init --recursive
 Please install the following additional modules for visualization using the commands below:
 
 ```bash
-pip install -e .[visulization] --no-build-isolation
+pip install -e .[visualization] --no-build-isolation
 ```
 
 <details>


### PR DESCRIPTION
Renamed the optional dependency extra 'visulization' to 'visualization' in 'pyproject.toml' and updated 'README.md' so 'pip install -e .[visualization]' matches the defined extra. 